### PR TITLE
profile link on navbar now sends user to /profile instead of /user/:id

### DIFF
--- a/travel_app/app/views/layouts/application.html.erb
+++ b/travel_app/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 	    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 	      <ul class="nav navbar-nav">
 			  <% if current_user %>
-			    <li><%= link_to "Profile", user_path(current_user) %></li>
+			    <li><%= link_to "Profile", "/profile" %></li>
 			    <li><%= link_to "Log Out", logout_path %></li>
 			  <% else %>
 			    <li><%= link_to "Sign Up", new_user_path %></li>


### PR DESCRIPTION
when you click on the profile button, it sends you to the /profile endpoint now, instead of /user/:id
